### PR TITLE
Fix two typos in erbium.

### DIFF
--- a/man/erbium.8
+++ b/man/erbium.8
@@ -34,7 +34,7 @@ when run separately there is no integration between the protocols.
 
 .SH OPTIONS
 .IP path/to/erbium.conf
-Provide the path to the configuration file to read instea of erbium.conf
+Provide the path to the configuration file to read instead of erbium.conf
 
 .SH ENVIRONMENT
 .IP RUST_BACKTRACE=full

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ impl std::fmt::Display for Error {
                 write!(f, "UTF8 Decoding error reading configuration file: {}", e)
             }
             Error::DhcpError(e) => write!(f, "DHCP Config loading error: {}", e),
-            Error::YamlError(e) => write!(f, "Yaml parse erorr while reading configuration: {}", e),
+            Error::YamlError(e) => write!(f, "Yaml parse error while reading configuration: {}", e),
             Error::MissingConfig => write!(f, "Configuration is empty/missing"),
             Error::MultipleConfigs => {
                 write!(f, "Configuration file contains multiple configurations")


### PR DESCRIPTION
Fix typo in erbium(8): instea => instead.
