### PR TITLE
Add a crate2nix workflow to automatically update Cargo.nix

### DIFF
--- a/.github/workflows/crate2nix.yaml
+++ b/.github/workflows/crate2nix.yaml
@@ -1,0 +1,38 @@
+name: "Update crate2nix"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update-crate2nix:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && github.repository == 'isomer/erbium'"
+    steps:
+    - name: Checking out the repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Installing Nix
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Install crate2nix
+      run: |
+        nix-env -iA cachix -f https://cachix.org/api/v1/install
+        $HOME/.nix-profile/bin/cachix use eigenvalue
+        nix-env -i -f https://github.com/kolloch/crate2nix/tarball/0.8.0 
+
+    - name: Run crate2nix
+      run: |
+        $HOME/.nix-profile/bin/crate2nix generate
+
+    - name: Commit crate2nix and push to master
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "Update Cargo.nix [ci skip]"
+        branch: 'master'
+        file_pattern: Cargo.nix


### PR DESCRIPTION
This means that contributors who know Rust don't need to know how to
Cargo.nix, and it just happens automatically when changes are made.

This may be overly sensitive (i.e. Cargo.nix might change on unrelated
changes), and if so we should do something else.