### PR TITLE
crate2nix improvements

### DIFF
--- a/.github/workflows/crate2nix.yaml
+++ b/.github/workflows/crate2nix.yaml
@@ -24,7 +24,8 @@ jobs:
       run: |
         nix-env -iA cachix -f https://cachix.org/api/v1/install
         $HOME/.nix-profile/bin/cachix use eigenvalue
-        nix-env -i -f https://github.com/kolloch/crate2nix/tarball/0.8.0 
+        # A version post 0.8.0 with https://github.com/kolloch/crate2nix/issues/83 fixed
+        nix-env -i -f https://github.com/kolloch/crate2nix/tarball/e07af104b8e41d1cd7e41dc7ac3fdcdf4953efae
 
     - name: Run crate2nix
       run: |

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,2 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+(nixpkgs.callPackage ./Cargo.nix { inherit nixpkgs; }).rootCrate.build


### PR DESCRIPTION
* Use a newer crate2nix to properly support actually building the thing (otherwise it's broken due to https://github.com/kolloch/crate2nix/issues/83)
* Add a default.nix to make building it easier (you can just `nix-build` and get a result!)

I'll let the workflow run to update the Crate.nix file.