### PR TITLE
Restore fall back to default erbium.conf

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn go() -> Result<(), Error> {
      * Currently we don't do anything smart with the command line.
      */
     let args: Vec<_> = std::env::args_os().collect();
-    if args.len() > 2 || args[1].to_string_lossy().starts_with("-") {
+    if args.len() > 2 || (args.len() == 2 && args[1].to_string_lossy().starts_with("-")) {
         return Err(Error::CommandLineError(format!(
             "Usage: {} <configfile>",
             args[0].to_string_lossy()


### PR DESCRIPTION
In commit b75df046b7 was detection of options added.  But starting
erbium without configuration file option triggers now an error.

|$ target/debug/erbium
|[2021-01-03T18:36:31Z INFO  erbium] erbium 0.2.6 (b75df04)
|thread 'main' panicked at 'index out of bounds:
|  the len is 1 but the index is 1', src/main.rs:59:26
|note: run with `RUST_BACKTRACE=1` environment variable
|      to display a backtrace

This change restores the behaviour of falling back to `erbium.conf`
as default configuration file.