### PR TITLE
Implement parsing RA, fix CaptivePortal opt bug.

### DIFF
--- a/src/pktparser/mod.rs
+++ b/src/pktparser/mod.rs
@@ -147,6 +147,16 @@ impl<'l> Buffer<'l> {
     }
 }
 
+impl<'l> std::fmt::Display for Buffer<'l> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(f, "[")?;
+        for byte in &self.buffer[self.offset..] {
+            write!(f, "{:x} ", byte)?;
+        }
+        write!(f, "]")
+    }
+}
+
 #[test]
 fn test_get_u8() {
     let data = [1, 2, 3];


### PR DESCRIPTION
I was trying to implement the parsing side for Router Advertisements, when I noticed that the captive portal option parser was broken (there was a `&` instead of `%` for the padding, but the example string just happened to get lucky in the test). This CL includes both the padding bug fix and `parse_nd_rtr_advert`.

I think in the next CLs I would like to propose adding a trait for serializing and deserializing so that it's a bit more composable to work with all these packets.