### PR TITLE
Github Actions: Change CodeQL to v2.

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
v1 got deprecated: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated