### PR TITLE
Relax dependency on netlink-packet-{core,route}

### DIFF
--- a/crates/erbium-net/Cargo.toml
+++ b/crates/erbium-net/Cargo.toml
@@ -10,8 +10,8 @@ bytes = { version = ">=1.3" }
 futures = "0.3.8"
 log = "0.4"
 mio = { version = "0.8", features=["net", "os-poll"] }
-netlink-packet-core = "0.5"
-netlink-packet-route = "0.15"
+netlink-packet-core = ">=0.4,<=0.5"
+netlink-packet-route = ">=0.12,<=0.15"
 netlink-sys = { version="0.8", features=["tokio_socket"] }
 nix = { version = "0.26", features=["net"] }
 tokio = { version = "1.8.4", features = ["full"] }


### PR DESCRIPTION
Relax dependency on netlink-packet-{core,route}

This allows building erbium-net on current Debian
