### PR TITLE
Relax version constraints in a few more places

### DIFF
--- a/crates/erbium-core/Cargo.toml
+++ b/crates/erbium-core/Cargo.toml
@@ -57,5 +57,5 @@ name = "erbium"
 path = "src/lib.rs"
 
 [build-dependencies]
-vergen = "8"
+vergen = ">=6,<=8"
 

--- a/crates/erbium-core/Cargo.toml
+++ b/crates/erbium-core/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = { version = "0.1.42" }
 byteorder = "1.4.3"
 bytes = "1.0"
 digest = "0.10.3"
-env_logger = "0.10"
+env_logger = ">=0.9 ,<=0.10"
 erbium-net = { path = "../erbium-net" }
 futures = "0.3.8"
 hmac = "0.12.1"

--- a/crates/erbium-net/Cargo.toml
+++ b/crates/erbium-net/Cargo.toml
@@ -6,7 +6,7 @@ description = "Network services for small/home networks - Low level networking a
 version.workspace = true
 
 [dependencies]
-bytes = { version = ">=1.3" }
+bytes = { version = ">=1.2" }
 futures = "0.3.8"
 log = "0.4"
 mio = { version = "0.8", features=["net", "os-poll"] }

--- a/crates/erbium-net/Cargo.toml
+++ b/crates/erbium-net/Cargo.toml
@@ -10,8 +10,8 @@ bytes = { version = ">=1.2" }
 futures = "0.3.8"
 log = "0.4"
 mio = { version = "0.8", features=["net", "os-poll"] }
-netlink-packet-core = "0.5"
-netlink-packet-route = "0.15"
+netlink-packet-core = ">=0.4, <=0.5"
+netlink-packet-route = ">=0.12, <=0.15"
 netlink-sys = { version="0.8", features=["tokio_socket"] }
 nix = { version = "0.26", features=["net"] }
 tokio = { version = "1.8.4", features = ["full"] }


### PR DESCRIPTION
Relax version constraints in a few more places

This is necessary to build on current Debian unstable
