### PR TITLE
Fix handling of UNIX sockaddr path lengths.

### DIFF
--- a/crates/erbium-core/src/acl.rs
+++ b/crates/erbium-core/src/acl.rs
@@ -83,8 +83,7 @@ impl Acl {
                 .unwrap_or(true);
         /* Check that the addr is unix */
         if let Some(unix) = self.unix {
-            use erbium_net::addr::NetAddrExt as _;
-            ok = ok && attr.addr.to_unix_addr().is_some() == unix;
+            ok = ok && attr.addr.as_unix_addr().is_some() == unix;
         }
 
         if ok {

--- a/crates/erbium-core/src/http.rs
+++ b/crates/erbium-core/src/http.rs
@@ -271,7 +271,6 @@ pub async fn run(
 ) -> Result<(), Error> {
     // Set up all the listeners and listen on them.
     for addr in &conf.read().await.listeners {
-        use erbium_net::addr::NetAddrExt as _;
         use nix::sys::socket::{AddressFamily::*, SockaddrLike as _};
         use tokio::net::{TcpListener, UnixListener};
         match addr.family() {
@@ -292,7 +291,7 @@ pub async fn run(
                 tokio::task::spawn(run_listener(conf.clone(), dhcp.clone(), listener));
             }
             Some(Unix) => {
-                let s = addr.to_unix_addr().unwrap();
+                let s = addr.as_unix_addr().unwrap();
                 let listener;
                 if let Some(path) = s.path() {
                     loop {


### PR DESCRIPTION
Under linux, sockaddr_un does not have a length field, but the nix Rust wrapper for it does keep track of the length, and this must be managed correctly or else UnixAddr::path() will return strings that are too long. Without this change I get either:

Error: Failed to listen on /var/lib/erbium/control<binary garbage>: path must be shorter than libc::sockaddr_un.sun_path

or

Error: Failed to cleanup /var/lib/erbium/control: file name contained an unexpected NUL byte

Prior to the resolution of https://github.com/nix-rust/nix/issues/1800 passing the maximum size of a sockaddr_un path was probably the right thing to do, but now it seems it is no longer correct, and furthermore there is now a .as_unix_addr() method on SockaddrStorage.