### PR TITLE
Update the time crate

### DIFF
--- a/.github/workflows/crate2nix.yaml
+++ b/.github/workflows/crate2nix.yaml
@@ -24,7 +24,7 @@ jobs:
       run: |
         nix-env -iA cachix -f https://cachix.org/api/v1/install
         $HOME/.nix-profile/bin/cachix use eigenvalue
-        nix-env -i -f https://github.com/nix-community/crate2nix/tarball/0.12.0
+        nix-env -i -f https://github.com/nix-community/crate2nix/tarball/0.14.1
 
 
     - name: Run crate2nix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,13 +1488,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
+ "num-conv",
  "num_threads",
  "powerfmt",
  "serde",
@@ -1504,10 +1511,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 


### PR DESCRIPTION
The old time crate is incompatible with newer Rust versions, because of some (IMO) poor decision making and lack of a solid backwards compatibility guarantee.

But... the decisions were made, and so we're now in this state. It's unfortunate but the easiest thing to do is to just bump the `time` version.

While I'm here, bump crate2nix's version.