### PR TITLE
crate2nix: bump install-nix-action version to v29

### DIFF
--- a/.github/workflows/crate2nix.yaml
+++ b/.github/workflows/crate2nix.yaml
@@ -16,16 +16,17 @@ jobs:
         fetch-depth: 0
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@v29
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
 
     - name: Install crate2nix
       run: |
         nix-env -iA cachix -f https://cachix.org/api/v1/install
         $HOME/.nix-profile/bin/cachix use eigenvalue
         nix-env -i -f https://github.com/nix-community/crate2nix/tarball/0.14.1
-
 
     - name: Run crate2nix
       run: |


### PR DESCRIPTION
Also add the magic-nix-cache action while I'm here, to speed up action runs.